### PR TITLE
BUG/MINOR: Fix benchmark typos and graphing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ssh-keygen -f k8benchmarks -t rsa
 4. Run terraform
 ```
 terraform init
-terraform apply -auto-approve -var 'aws_access_key=A=<ACCESS_KEY>' -var 'aws_secret_key=<SECRET_KEY>'
+terraform apply -auto-approve -var 'aws_access_key=<ACCESS_KEY>' -var 'aws_secret_key=<SECRET_KEY>'
 ```
 5. SSH to the instance provided within the terraform output
 6. After waiting for the Kubernetes cluster to fully initialize, execute the benchmarks.

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -68,7 +68,7 @@ spec:
     mkdir -p /home/ubuntu/.parallel
     touch /home/ubuntu/.parallel/will-cite
     A_INIT_CMD="apt-get update && apt-get -y -f install sysstat"
-    B_INIT_CMD="apt-get update;apt-get -y -f upgrade; apt-get -y -f install curl; curl -Lo /usr/local/bin/hey https://storage.googleapis.com/hey-release/hey_linux_amd64; chmod +x /usr/local/bin/hey;"
+    B_INIT_CMD="apt-get update;apt-get -y -f upgrade; apt-get -y -f install curl; curl -Lo /usr/local/bin/hey https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64; chmod +x /usr/local/bin/hey;"
     echo -e "$INJECTOR_YAML" >$temp_yaml
     kubectl create ns ubuntu-injector >/dev/null 2>&1 &
     kubectl -n ubuntu-injector apply -f $temp_yaml >/dev/null 2>&1

--- a/tools/chart.py
+++ b/tools/chart.py
@@ -38,8 +38,8 @@ def generate_single_bar(output, reqdata, title, ylabel, add_label=False):
     plt.xticks(x_pos, proxies)
     if add_label:
         autolabel(ax, rects)
-#    plt.savefig(output)
-    plt.show()
+    plt.savefig(output)
+#    plt.show()
 
 def generate_grouped_bar(output, title, ylabel, bar1, bar2, bar3, add_label=False, percentiles=False):
     global proxies


### PR DESCRIPTION
* chart python script wasn't properly saving images for single
instance benchmarks.
* The location of `hey` has been updated to reflect the latest
download location.
* Typo fixed in README